### PR TITLE
Add openStructOption & structOption

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -211,7 +211,7 @@
           # Anonymous structs are supported (e.g. for nesting) by omitting the
           # name.
           #
-          inherit (import ./struct.nix {inherit self typedef' typeError;}) struct openStruct;
+          inherit (import ./struct.nix {inherit self typedef' typeError;}) struct openStruct structOption openStructOption;
 
           enum = let
             plain = name: def:


### PR DESCRIPTION
The field type must be included within the {...} structAttrs.
If the field type exists within {...} structAttrs

contrast with:
```
(openStruct "option" {a = string; b = int; c = attrs any;}) {a = "x"; b = 5; c = {}; d = "5";}
{ a = "x"; b = 5; c = { ... }; d = "5"; }

(openStruct "option" {a = string; b = int; c = attrs any;}) {a = "x"; b = 5; d = "5";}
 expected 'option'-struct, but found:
 missing required attrs<any> field 'c'

(openStructOption "option" {a = string; b = int; c = attrs any;}) {a = "x"; b = 5; d = "5";}
{ a = "x"; b = 5; d = "5"; }
```